### PR TITLE
Update Gambit port

### DIFF
--- a/scmxlate.scm
+++ b/scmxlate.scm
@@ -218,11 +218,6 @@
     ((stk stklos)
      (lambda (f)
        (system (string-append "rm " f))))
-;    ((gambit)
-;     ;## causes problems with other Scheme dialects
-;     (lambda (f)
-;       ((eval (call-with-input-string "##shell-command" read))
-;        (string-append "rm " f))))
     (else (lambda (f) #t))))
 
 (define ensure-file-deleted
@@ -589,8 +584,10 @@
                        (let ((datum->syntax (lambda (x y) y))
                              (syntax->datum (lambda (x) x)))
                          (,(caddr e) (cons ',(cadr e) _args)))))))
-         (if (and #f (eqv? *dialect* 'gambit))
-           ;disabled; but why was it ever needed?
+         (if (eqv? *dialect* 'gambit)
+             ;; To use Gambit macros outside the file where they are
+             ;; defined you need to eval them to add them to the runtime
+             ;; (or include them in each file).
              `(begin ,e-t
                      (eval ',e-t))
              e-t))))


### PR DESCRIPTION
scmxlate.scm:

1.  Delete Gambit comment from obliterate-file definition (it's contained in the first case).

2.  Re-enable explicit "eval" of Gambit macros so they're added to the runtime system.

This fixes the following problem:
```
heine:~/programs/schelog-dorai> gsi scmxlate.scm
This is scmxlate, v 20200324
What is your Scheme dialect?
     (bigloo chez chibi gambit gauche 
      guile mitscheme mzscheme petite pscheme 
      racket scheme48 scm scsh stk 
      sxm umbscheme other)
gambit

Porting schelog.scm ...
Resulting file is `my-schelog.scm'.
You may want to rename it.
heine:~/programs/schelog-dorai> gsi
Gambit v4.9.4-56-g69fb3aa5

> (load "my-schelog")
"/home/lucier/programs/schelog-dorai/my-schelog.scm"
> (load examples/houses.scm")
*** ERROR IN (stdin)@2.26 -- Incomplete form, EOF reached
> (load "examples/houses.scm")
*** ERROR IN "examples/houses.scm"@28.15 -- Unbound variable: %rel
1> 
> 
*** EOF again to exit
heine:~/programs/schelog-dorai> gsi scmxlate-new.scm 
This is scmxlate, v 20200324
What is your Scheme dialect?
     (bigloo chez chibi gambit gauche 
      guile mitscheme mzscheme petite pscheme 
      racket scheme48 scm scsh stk 
      sxm umbscheme other)
gambit

Porting schelog.scm ...
Resulting file is `my-schelog.scm'.
You may want to rename it.
heine:~/programs/schelog-dorai> gsi
Gambit v4.9.4-56-g69fb3aa5

> (load "my-schelog")         
"/home/lucier/programs/schelog-dorai/my-schelog.scm"
> (load "examples/houses.scm")
"/home/lucier/programs/schelog-dorai/examples/houses.scm"
```